### PR TITLE
Bumb sbt-pgp version to 0.8.1, corrects "dispatch" version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ resolvers += Classpaths.typesafeResolver
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")


### PR DESCRIPTION
The sbt-pgp plugin v0.8 contained an incorrect selection
of the dispatch library version (the _2.9.1 version is
selected). That also has the effect of making it
incompatible with dbuild. Fixed in sbt-pgp 0.8.1.
