### PR TITLE
Automate release: settings for dependency versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION compile
+  - sbt ++$TRAVIS_SCALA_VERSION clean update compile
 scala:
   - 2.11.0-SNAPSHOT
 jdk:
@@ -9,3 +9,6 @@ jdk:
 notifications:
   email:
     - adriaan.moors@typesafe.com
+
+# if we get weird timeouts, see https://github.com/spray/spray/pull/233
+# 'set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)'

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import DependencyKeys.scalaXmlVersion
+import VersionKeys._
+
 
 organization := "org.scala-lang.modules"
 
@@ -6,8 +7,17 @@ name := "scala-partest"
 
 version := "1.0.0-SNAPSHOT"
 
-// TODO: bump to 1.0.0-RC5 as soon as it's out
+scalaVersion := "2.11.0-M6"
+
+snapshotScalaBinaryVersion := "2.11.0-M6"
+
 scalaXmlVersion := "1.0.0-RC6"
+
+scalaCheckVersion := "1.10.1"
+
+// DOUBLETHINK YOUR WAY OUT OF EDITING BELOW (THERE IS NO BELOW)
+
+scalaBinaryVersion := deriveBinaryVersion(scalaVersion.value, snapshotScalaBinaryVersion.value)
 
 // so we don't have to wait for sonatype to synch to maven central when deploying a new module
 resolvers += Resolver.sonatypeRepo("releases")
@@ -22,11 +32,8 @@ libraryDependencies += "com.googlecode.java-diff-utils" % "diffutils"      % "1.
 
 libraryDependencies += "org.scala-sbt"                  % "test-interface" % "1.0"
 
-// mark as intransitive because 1.10.1 released against Scala 2.11.0-M6 has wrong dependencies
-// once we upgrade to M7 the intransitive bit can be dropped
-// however, provided should stay; if one wants to run scalacheck tests it should depend on
-// scalacheck explicitly
-libraryDependencies += "org.scalacheck"                %% "scalacheck"     % "1.10.1" % "provided" intransitive()
+// to run scalacheck tests, depend on scalacheck separately
+libraryDependencies += "org.scalacheck"                %% "scalacheck"     % scalaCheckVersion.value % "provided"
 
 // mark all scala dependencies as provided which means one has to explicitly provide them when depending on partest
 // this allows for easy testing of modules (like scala-xml) that provide tested classes themselves and shouldn't
@@ -39,16 +46,9 @@ libraryDependencies += "org.scala-lang"                 % "scala-reflect"  % sca
 
 libraryDependencies += "org.scala-lang"                 % "scala-compiler" % scalaVersion.value % "provided" intransitive()
 
-// standard stuff follows:
-scalaVersion := "2.11.0-M6"
-
-// NOTE: not necessarily equal to scalaVersion
-// (e.g., during PR validation, we override scalaVersion to validate,
-// but don't rebuild scalacheck, so we don't want to rewire that dependency)
-scalaBinaryVersion := "2.11.0-M6"
-
 // don't use for doc scope, scaladoc warnings are not to be reckoned with
-scalacOptions in (Compile, compile) ++= Seq("-optimize", "-Xfatal-warnings", "-feature", "-deprecation", "-unchecked", "-Xlint")
+// "-Xfatal-warnings",
+scalacOptions in (Compile, compile) ++= Seq("-optimize", "-feature", "-deprecation", "-unchecked", "-Xlint")
 
 
 // Generate $name.properties to store our version as well as the scala version used to build

--- a/project/keys.scala
+++ b/project/keys.scala
@@ -1,6 +1,15 @@
-object DependencyKeys {
+object VersionKeys {
   import sbt.settingKey
 
   // To facilitate scripted build of all modules (while we're working on getting dbuild up and running)
   val scalaXmlVersion = settingKey[String]("Version to use for the scala-xml dependency.")
+  val scalaCheckVersion = settingKey[String]("Version to use for the scalacheck dependency.")
+
+  val snapshotScalaBinaryVersion = settingKey[String]("The Scala binary version to use when building against Scala SNAPSHOT.")
+
+  def deriveBinaryVersion(sv: String, snapshotScalaBinaryVersion: String) = sv match {
+    case snap_211 if snap_211.startsWith("2.11") &&
+                     snap_211.contains("-SNAPSHOT") => snapshotScalaBinaryVersion
+    case sv => sbt.CrossVersion.binaryScalaVersion(sv)
+  }
 }


### PR DESCRIPTION
Enable building against Scala 2.11.0-SNAPSHOT.

Disable `-Xfatal-warnings` to make PR validation less painful.
TODO: Re-enable for travis / nightlies.

TODO: Bump to Scala 2.11.0-M7, Scalacheck 1.11.0 once they're out.
