### PR TITLE
Add support for Java 8 in filtered check feature.

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -254,6 +254,7 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
       val (invert, token) =
         if (f startsWith "!") (true, f drop 1) else (false, f)
       val cond = token.trim match {
+        case "java8"  => javaVersion startsWith "1.8"
         case "java7"  => javaVersion startsWith "1.7"
         case "java6"  => javaVersion startsWith "1.6"
         case "avian"  => isAvian


### PR DESCRIPTION
Not much to easy. Added another case so we can use `#partest java8`
syntax for marking fragments of check files that should be used when
testing on Java 8.
