### PR TITLE
SI-8382 Restore partest.debug

### DIFF
--- a/src/main/scala/scala/tools/partest/PartestTask.scala
+++ b/src/main/scala/scala/tools/partest/PartestTask.scala
@@ -9,7 +9,7 @@
 package scala.tools
 package partest
 
-import scala.util.Properties.setProp
+import scala.tools.nsc.Properties.propOrFalse
 import scala.tools.ant.sabbus.CompilationPathProperty
 import java.lang.reflect.Method
 import org.apache.tools.ant.Task
@@ -112,7 +112,7 @@ class PartestTask extends Task with CompilationPathProperty with ScalaTask {
   }
 
   override def execute() {
-    if (debug || sys.props.contains("partest.debug")) {
+    if (debug || propOrFalse("partest.debug")) {
       NestUI.setDebug()
     }
 

--- a/src/main/scala/scala/tools/partest/nest/ConsoleRunner.scala
+++ b/src/main/scala/scala/tools/partest/nest/ConsoleRunner.scala
@@ -8,7 +8,7 @@ package partest
 package nest
 
 import utils.Properties._
-import scala.tools.nsc.Properties.{ versionMsg, setProp }
+import scala.tools.nsc.Properties.{ versionMsg, propOrFalse, setProp }
 import scala.collection.{ mutable, immutable }
 import TestKinds._
 import scala.reflect.internal.util.Collections.distinctBy
@@ -93,9 +93,9 @@ class ConsoleRunner(argstr: String) extends {
   }
 
   def run(): Unit = {
-    if (optDebug) NestUI.setDebug()
-    if (optVerbose) NestUI.setVerbose()
-    if (optTerse) NestUI.setTerse()
+    if (optDebug || propOrFalse("partest.debug")) NestUI.setDebug()
+    if (optVerbose)  NestUI.setVerbose()
+    if (optTerse)    NestUI.setTerse()
     if (optShowDiff) NestUI.setDiffOnFail()
 
     // Early return on no args, version, or invalid args


### PR DESCRIPTION
Use it to set debug mode (which for instance leaves object files
behind for inspection). (--debug is a synonym for the command
line tool.)
