### PR TITLE
Make ant a provided dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ scalacOptions in (Compile, compile) ++= Seq("-optimize", "-feature", "-deprecati
 
 // dependencies
 // versions involved in integration builds / that change frequently should be keys, set above!
-libraryDependencies += "org.apache.ant"                 % "ant"            % "1.8.4"
+libraryDependencies += "org.apache.ant"                 % "ant"            % "1.8.4" % "provided"
 
 libraryDependencies += "com.googlecode.java-diff-utils" % "diffutils"      % "1.3.0"
 


### PR DESCRIPTION
Ant is only needed to compile the Partest ant task. At runtime, the
task is run by the Ant runner, so ant.jar and friends are already
provided.

In the scala build, this removes ant from the compile classpath of
partest-extras, and from the runtime classpath of test.junit and the
`test/partest` script. Nothing in partest other than the task depends
on Ant, so there is no need to explicitly provide ant anywhere. Both
`ant test.run` and `test/partest` should work fine with this change.

The motivation for this is to prevent ant from appearing several time on
the classpath, see [1].

[1] https://groups.google.com/d/topic/scala-internals/EuMX5xu347o/discussion
