### PR TITLE
javaOpts property for partest ant task

### DIFF
--- a/src/main/scala/scala/tools/partest/PartestTask.scala
+++ b/src/main/scala/scala/tools/partest/PartestTask.scala
@@ -47,6 +47,7 @@ class PartestTask extends Task with CompilationPathProperty with ScalaTask {
   private var jUnitReportDir: Option[File] = None
   private var javaccmd: Option[File] = None
   private var javacmd: Option[File] = Option(sys.props("java.home")) map (x => new File(x, "bin/java"))
+  private var javaOpts: Option[Seq[String]] = None
   private var scalacArgs: Option[Seq[Argument]] = None
   private var srcDir: Option[String] = None
   private var colors: Int = 0
@@ -82,6 +83,11 @@ class PartestTask extends Task with CompilationPathProperty with ScalaTask {
 
   def setJavaCmd(input: File) {
     javacmd = Some(input)
+  }
+
+  def setJavaOpts(input: String) {
+    val s = input.split(' ')
+    javaOpts = Some(javaOpts.getOrElse(Seq()) ++ s)
   }
 
   def setKinds(input: String) {
@@ -124,7 +130,7 @@ class PartestTask extends Task with CompilationPathProperty with ScalaTask {
     })
 
     var failureCount = 0
-    val summary = new scala.tools.partest.nest.AntRunner(srcDir.getOrElse(null), new URLClassLoader(compilationPath.get.list.map(Path(_).toURL)), javacmd.getOrElse(null), javaccmd.getOrElse(null), scalacArgsFlat) {
+    val summary = new scala.tools.partest.nest.AntRunner(srcDir.getOrElse(null), new URLClassLoader(compilationPath.get.list.map(Path(_).toURL)), javacmd.getOrElse(null), javaccmd.getOrElse(null), scalacArgsFlat, javaOpts) {
       def echo(msg: String): Unit = PartestTask.this.log(msg)
       def log(msg: String): Unit = PartestTask.this.log(msg)
 

--- a/src/main/scala/scala/tools/partest/nest/AntRunner.scala
+++ b/src/main/scala/scala/tools/partest/nest/AntRunner.scala
@@ -12,7 +12,7 @@ package nest
 import java.net.URLClassLoader
 
 // not using any Scala types to ease calling across different scala versions
-abstract class AntRunner(srcDir: String, testClassLoader: URLClassLoader, javaCmd: File, javacCmd: File, scalacArgs: Array[String]) extends SuiteRunner(
+abstract class AntRunner(srcDir: String, testClassLoader: URLClassLoader, javaCmd: File, javacCmd: File, scalacArgs: Array[String], javaOpts: Option[Seq[String]]) extends SuiteRunner(
   testSourcePath = Option(srcDir) getOrElse PartestDefaults.sourcePath,
   new FileManager(testClassLoader = testClassLoader),
   updateCheck = false,
@@ -20,6 +20,8 @@ abstract class AntRunner(srcDir: String, testClassLoader: URLClassLoader, javaCm
   javaCmdPath = Option(javaCmd).map(_.getAbsolutePath) getOrElse PartestDefaults.javaCmd,
   javacCmdPath = Option(javacCmd).map(_.getAbsolutePath) getOrElse PartestDefaults.javacCmd,
   scalacExtraArgs = scalacArgs) {
+
+  for (jOpts <- javaOpts) System.setProperty("partest.java_opts", jOpts mkString " ")
 
   def error(msg: String): Nothing = sys.error(msg)
   def echo(msg: String): Unit

--- a/src/main/scala/scala/tools/partest/nest/SBTRunner.scala
+++ b/src/main/scala/scala/tools/partest/nest/SBTRunner.scala
@@ -23,7 +23,7 @@ import java.net.URLClassLoader
 // called reflectively from scala-partest-test-interface
 class SBTRunner(partestFingerprint: Fingerprint, eventHandler: EventHandler, loggers: Array[Logger],
     srcDir: String, testClassLoader: URLClassLoader, javaCmd: File, javacCmd: File, scalacArgs: Array[String])
-    extends AntRunner(srcDir, testClassLoader, javaCmd, javacCmd, scalacArgs) {
+    extends AntRunner(srcDir, testClassLoader, javaCmd, javacCmd, scalacArgs, None) {
   override def error(msg: String): Nothing = sys.error(msg)
   def echo(msg: String): Unit = loggers foreach { l => l.info(msg) }
   def log(msg: String): Unit = loggers foreach { l => l.debug(msg) }


### PR DESCRIPTION
this fixes the PermGen issue in https://github.com/scala/scala/pull/4296 (we'll pass ANT_OPTS to the new javaOpts parameter).

review by @adriaanm - in particular, `SBTRunner.scala`. I did not add a parameter there to keep it compatible.

don't merge - i want to push a git tag to scala/scala-partest first to trigger a release