### PR TITLE
be compatible with more Scala versions

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/PathSettings.scala
+++ b/src/main/scala/scala/tools/partest/nest/PathSettings.scala
@@ -28,7 +28,7 @@ object PathSettings {
   private def cwd = Directory.Current getOrElse sys.error("user.dir property not set")
   private def isPartestDir(d: Directory) = (d.name == "test") && (d / testSourcePath isDirectory)
   private def findJar(name: String, ds: Directory*): Either[String, File] =
-    ds.toStream flatMap (_.files) filter (_ hasExtension "jar") find ( _.name startsWith name ) map (Right(_)) getOrElse
+    ds.iterator flatMap (_.files) filter (_ hasExtension "jar") find ( _.name startsWith name ) map (Right(_)) getOrElse
       Left(s"'${name}.jar' not found in '${ds map (_.path) mkString ", "}'.")
 
   // Directory <root>/test


### PR DESCRIPTION
see https://github.com/scala/scala/pull/4640 for details.
in that PR (targeted for 2.12.0-M3), we are making a binary
incompatible change to Stream. by avoiding using Stream at all here,
we avoid running afoul of the incompatibility.

Stream is arguably overkill here anyway, Iterator is just fine.
so there's no need to change the code back after we're over
the M2/M3 incompatibility hump.