### PR TITLE
Issue #25 use filtered check for git diff

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/FileManager.scala
+++ b/src/main/scala/scala/tools/partest/nest/FileManager.scala
@@ -10,15 +10,9 @@ package nest
 
 import java.io.{
   File,
-  FilenameFilter,
   IOException,
-  StringWriter,
-  FileInputStream,
-  FileOutputStream,
-  BufferedReader,
-  FileReader,
-  PrintWriter,
-  FileWriter
+  OutputStreamWriter,
+  FileOutputStream
 }
 import java.net.URI
 import scala.reflect.io.AbstractFile
@@ -97,6 +91,19 @@ object FileManager {
     val diff = difflib.DiffUtils.diff(original.asJava, revised.asJava)
     if (diff.getDeltas.isEmpty) ""
     else difflib.DiffUtils.generateUnifiedDiff(originalName, revisedName, original.asJava, diff, 1).asScala.mkString("\n")
+  }
+
+  def withTempFile[A](outFile: File, fileBase: String, lines: Seq[String])(body: File => A): A = {
+    val prefix = s"tmp-$fileBase"
+    val suffix = ".check"
+    val f = File.createTempFile(prefix, suffix, outFile)
+    try {
+      import scala.reflect.io.{ File => Feil }
+      Feil(f).writeAll(lines map (line => f"$line%n"): _*)
+      body(f)
+    } finally {
+      f.delete()
+    }
   }
 }
 


### PR DESCRIPTION
Unlike normal diff, the git diff feature wasn't using the filtered
check file under `--show-diff`.

Now the sample displays just the bad line.

```
!! 1 - neg/t7494-no-options                      [output differs]
% diff /home/apm/projects/snytt/test/files/neg/t7494-no-options-neg.log /home/apm/projects/snytt/test/files/neg/t7494-no-options.check
@@ -1,7 +1,7 @@
 error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
-        parser   1  parse source into ASTs, perform simple desugaring
+        parser   0  parse source into ASTs, perform simple desugaring
          namer   2  resolve names, attach symbols to named trees
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
```
