### PR TITLE
Fix test failure problem in non-English environment

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -108,7 +108,9 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
       "-d",
       outDir.getAbsolutePath,
       "-classpath",
-      joinPaths(outDir :: testClassPath)
+      joinPaths(outDir :: testClassPath),
+      "-J-Duser.language=en",
+      "-J-Duser.country=US"
     ) ++ files.map(_.getAbsolutePath)
 
     pushTranscript(args mkString " ")


### PR DESCRIPTION
* For example, tests which expect some javac's error messages fail in Japanese environment
  since the error messages are localized in such a environment