### PR TITLE
Remove type alias for Classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ crossScalaVersions         := {
   if (java.startsWith("1.6."))
     Seq("2.11.7", "2.12.0-M1")
   else if (java.startsWith("1.8."))
-    Seq("2.12.0-M3")
+    Seq("2.12.0-M4")
   else
     sys.error(s"don't know what Scala versions to build on $java")
 }

--- a/src/main/scala/scala/tools/partest/package.scala
+++ b/src/main/scala/scala/tools/partest/package.scala
@@ -16,7 +16,6 @@ package object partest {
   type Directory    = scala.reflect.io.Directory
   type Path         = scala.reflect.io.Path
   type PathResolver = scala.tools.util.PathResolver
-  type ClassPath[T] = scala.tools.nsc.util.ClassPath[T]
   type StringWriter = java.io.StringWriter
 
   val SFile        = scala.reflect.io.File


### PR DESCRIPTION
The class has becom monomorphic in 2.12.x which
breaks this alias definition. It was unused within partest
itself, and the usage in scala/scala has been removed.

review by @lrytz