### PR TITLE
Avoid "".lines ambiguity

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -274,7 +274,7 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
     val prefix = "#partest"
     val b = new ListBuffer[String]()
     var on = true
-    for (line <- file2String(checkFile).lines) {
+    for (line <- file2String(checkFile).linesIfNonEmpty) {
       if (line startsWith prefix) {
         on = retainOn(line stripPrefix prefix)
       } else if (on) {
@@ -285,7 +285,7 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
   }
 
   def currentDiff = {
-    val logged = augmentString(file2String(logFile)).lines.toList
+    val logged = file2String(logFile).linesIfNonEmpty.toList
     val (other, othername) = if (checkFile.canRead) (filteredCheck, checkFile.getName) else (Nil, "empty")
     compareContents(original = other, revised = logged, originalName = othername, revisedName = logFile.getName)
   }

--- a/src/main/scala/scala/tools/partest/package.scala
+++ b/src/main/scala/scala/tools/partest/package.scala
@@ -48,6 +48,10 @@ package object partest {
   /** Sources have a numerical group, specified by name_7 and so on. */
   private val GroupPattern = """.*_(\d+)""".r
 
+  implicit class `special string ops`(private val s: String) extends AnyVal {
+    def linesIfNonEmpty: Iterator[String] = if (!s.isEmpty) s.lines else Iterator.empty
+  }
+
   implicit class FileOps(val f: File) {
     private def sf = SFile(f)
 
@@ -78,7 +82,7 @@ package object partest {
       }
 
     def fileContents: String    = try sf.slurp() catch { case _: java.io.FileNotFoundException => "" }
-    def fileLines: List[String] = augmentString(fileContents).lines.toList
+    def fileLines: List[String] = fileContents.linesIfNonEmpty.toList
   }
 
   implicit class PathOps(p: Path) extends FileOps(p.jfile) { }


### PR DESCRIPTION
Currently, "normalizing" the log file and "filtering" the check
file rely on `"".lines.isEmpty` to represent an absent or empty
file. This commit avoids extracting lines from an empty string.
