### PR TITLE
SI-7786 Partest finds javac 

### DIFF
--- a/src/main/scala/scala/tools/partest/PartestDefaults.scala
+++ b/src/main/scala/scala/tools/partest/PartestDefaults.scala
@@ -3,12 +3,13 @@ package partest
 
 import scala.concurrent.duration.Duration
 import scala.tools.nsc.Properties.{ propOrNone => prop }
+import scala.util.Properties.jdkHome
 import java.lang.Runtime.{ getRuntime => runtime }
 
 object PartestDefaults {
   def sourcePath  = prop("partest.srcdir")      getOrElse "files"
-  def javaCmd     = prop("partest.javacmd")     getOrElse "java"
-  def javacCmd    = prop("partest.javac_cmd")   getOrElse "javac"
+  def javaCmd     = prop("partest.javacmd")     orElse    jdkexec("java")  getOrElse "java"
+  def javacCmd    = prop("partest.javac_cmd")   orElse    jdkexec("javac") getOrElse "javac"
   def javaOpts    = prop("partest.java_opts")   getOrElse  ""     // opts when running java during tests
   def scalacOpts  = prop("partest.scalac_opts") getOrElse  ""
 
@@ -18,4 +19,13 @@ object PartestDefaults {
   def waitTime    = Duration(prop("partest.timeout") getOrElse "4 hours")
 
   //def timeout     = "1200000"   // per-test timeout
+
+  // probe for the named executable
+  private def jdkexec(name: String): Option[String] = {
+    import scala.reflect.io.Path, Path._
+    Some(Path(jdkHome) / "bin") filter (_.isDirectory) flatMap { p =>
+      val candidates = (p walkFilter { e => (e.name == name || e.name.startsWith(s"$name.")) && e.jfile.canExecute }).toList
+      (candidates find (_.name == name) orElse candidates.headOption) map (_.path)
+    }
+  }
 }

--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -111,7 +111,9 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
       joinPaths(outDir :: testClassPath),
       "-J-Duser.language=en",
       "-J-Duser.country=US"
-    ) ++ files.map(_.getAbsolutePath)
+    ) ++ (toolArgsFor(files)("javac")
+    ) ++ (files.map(_.getAbsolutePath)
+    )
 
     pushTranscript(args mkString " ")
     val captured = StreamCapture(runCommand(args, logFile))
@@ -439,7 +441,12 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
     perTest ++ perGroup
   }
 
-  def toolArgs(tool: String, split: Boolean = true): List[String] = {
+  // inspect sources for tool args
+  def toolArgs(tool: String, split: Boolean = true): List[String] =
+    toolArgsFor(sources(testFile))(tool, split)
+
+  // inspect given files for tool args
+  def toolArgsFor(files: List[File])(tool: String, split: Boolean = true): List[String] = {
     def argsplitter(s: String) = if (split) words(s) filter (_.nonEmpty) else List(s)
     def argsFor(f: File): List[String] = {
       import scala.util.matching.Regex
@@ -453,7 +460,7 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
       } finally src.close()
       args.flatten map argsplitter getOrElse Nil
     }
-    sources(testFile) flatMap argsFor
+    files flatMap argsFor
   }
 
   abstract class CompileRound {


### PR DESCRIPTION
Since partest is probably running with a JDK,
use JDK_HOME/bin/javac for compilation, if it
exists; otherwise, fall back to whatever is on
the command line.

Javac can still be specified explicitly.

Examines .java file header for "tool args" comments of the form
`javac: -deprecation`.
