### PR TITLE
SI-7696 Restore --show-log

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/main/scala/scala/tools/partest/nest/AbstractRunner.scala
@@ -94,6 +94,7 @@ abstract class AbstractRunner(argstr: String) extends {
     if (optVerbose)  NestUI.setVerbose()
     if (optTerse)    NestUI.setTerse()
     if (optShowDiff) NestUI.setDiffOnFail()
+    if (optShowLog)  NestUI.setLogOnFail()
 
     // Early return on no args, version, or invalid args
     if (optVersion) return echo(versionMsg)

--- a/src/main/scala/scala/tools/partest/nest/NestUI.scala
+++ b/src/main/scala/scala/tools/partest/nest/NestUI.scala
@@ -73,18 +73,16 @@ object NestUI {
     f"$word $testNumber - $testIdent%-40s$reasonString"
   }
 
-  def reportTest(state: TestState) = {
+  def reportTest(state: TestState, info: TestInfo) = {
     if (isTerse && state.isOk) {
       if (dotCount >= DotWidth) {
         outline("\n.")
         dotCount = 1
-      }
-      else {
+      } else {
         outline(".")
         dotCount += 1
       }
-    }
-    else {
+    } else {
       echo(statusLine(state))
       if (!state.isOk) {
         if (isDiffy) {
@@ -92,16 +90,11 @@ object NestUI {
           state.transcript find (_ startsWith differ) foreach (echo(_))
         }
         if (isLogging) {
-          import scala.util.matching.Regex
           def log(f: File) = {
             echo(bold(cyan(s"##### Log file '$f' from failed test #####\n")))
             echo(f.fileContents)
           }
-          val prompt = bold(red("% "))
-          val differ = raw"(?s)${Regex.quote(prompt)}diff (\S*).*".r
-          state.transcript.collect {
-            case differ(f) => f
-          } foreach (log(_))
+          if (info.logFile.canRead) log(info.logFile)
         }
       }
     }

--- a/src/main/scala/scala/tools/partest/nest/NestUI.scala
+++ b/src/main/scala/scala/tools/partest/nest/NestUI.scala
@@ -73,7 +73,7 @@ object NestUI {
     f"$word $testNumber - $testIdent%-40s$reasonString"
   }
 
-  def reportTest(state: TestState, info: TestInfo) = {
+  def reportTest(state: TestState, info: TestInfo) =
     if (isTerse && state.isOk) {
       if (dotCount >= DotWidth) {
         outline("\n.")
@@ -85,20 +85,22 @@ object NestUI {
     } else {
       echo(statusLine(state))
       if (!state.isOk) {
+        def showLog() = if (info.logFile.canRead) {
+          echo(bold(cyan(s"##### Log file '${info.logFile}' from failed test #####\n")))
+          echo(info.logFile.fileContents)
+        }
         if (isDiffy) {
           val differ = bold(red("% ")) + "diff "
-          state.transcript find (_ startsWith differ) foreach (echo(_))
-        }
-        if (isLogging) {
-          def log(f: File) = {
-            echo(bold(cyan(s"##### Log file '$f' from failed test #####\n")))
-            echo(f.fileContents)
+          val diffed = state.transcript find (_ startsWith differ)
+          diffed match {
+            case Some(diff) => echo(diff)
+            case None if !isLogging && !isPartestVerbose => showLog()
+            case _ => ()
           }
-          if (info.logFile.canRead) log(info.logFile)
         }
+        if (isLogging) showLog()
       }
     }
-  }
 
   def echo(message: String): Unit = synchronized {
     leftFlush()

--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -42,8 +42,35 @@ class TestTranscript {
   }
 }
 
+trait TestInfo {
+  /** pos/t1234 */
+  def testIdent: String
+
+  /** pos */
+  def kind: String
+
+  // inputs
+
+  /** pos/t1234.scala or pos/t1234 if dir */
+  def testFile: File
+
+  /** pos/t1234.check */
+  def checkFile: File
+
+  /** pos/t1234.flags */
+  def flagsFile: File
+
+  // outputs
+
+  /** pos/t1234-pos.obj */
+  def outFile: File
+
+  /** pos/t1234-pos.log */
+  def logFile: File
+}
+
 /** Run a single test. Rubber meets road. */
-class Runner(val testFile: File, val suiteRunner: SuiteRunner) {
+class Runner(val testFile: File, val suiteRunner: SuiteRunner) extends TestInfo {
 
   import suiteRunner.{fileManager => fm, _}
   val fileManager = fm
@@ -802,7 +829,7 @@ class SuiteRunner(
           catch {
             case t: Throwable => throw new RuntimeException(s"Error running $testFile", t)
           }
-        NestUI.reportTest(state)
+        NestUI.reportTest(state, runner)
         runner.cleanup()
         state
       }

--- a/src/main/scala/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/main/scala/scala/tools/partest/nest/RunnerSpec.scala
@@ -36,6 +36,7 @@ trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
 
   heading("Test output options:")
   val optShowDiff     = "show-diff"    / "show diffs for failed tests"       --?
+  val optShowLog      = "show-log"     / "show log files for failed tests"   --?
   val optVerbose      = "verbose"      / "show verbose progress information" --?
   val optTerse        = "terse"        / "show terse progress information"   --?
   val optDebug        = "debug"        / "enable debugging output"           --?


### PR DESCRIPTION
If a test exits abnormally, there is no diff in the test transcript.  `--show-log` shows the log, which probably contains a stack trace in the case of catastrophic failure.

Also, sometimes diffs are too obscure, and it's simply easier to examine the entire test output.
(That's the argument for a distinct `--show-log` option; maybe `--show-diff` should show the log for abnormal completion, too.)

For --show-diff output

```
# starting 1 test in run
!! 1 - run/foo.scala                             [output differs]
% diff /home/apm/projects/snytt/test/files/run/foo-run.log /home/apm/projects/snytt/test/files/run/foo.check---
+++ foo-run.log
@@ -1,0 +1,1 @@
+oops
#0/1 passed, 1 failed in run
```

--show-log shows

```
# starting 1 test in run
!! 1 - run/foo.scala                             [output differs]
##### Log file '/home/apm/projects/snytt/test/files/run/foo-run.log' from failed test #####

oops

#0/1 passed, 1 failed in run
```
