### PR TITLE
Use the correct scalac options when run from sbt

### DIFF
--- a/src/main/scala/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/main/scala/scala/tools/partest/nest/DirectCompiler.scala
@@ -67,7 +67,7 @@ class DirectCompiler(val runner: Runner) {
     val Xplugin = if (xplugs.isEmpty) Nil else List(xprefix +
       (xplugs map (_ stripPrefix xprefix) flatMap (_ split pathSeparator) map absolutize mkString pathSeparator)
     )
-    runner.suiteRunner.scalacExtraArgs ++ PartestDefaults.scalacOpts.split(' ') ++ others ++ Xplugin
+    runner.suiteRunner.scalacExtraArgs ++ runner.suiteRunner.scalacOpts.split(' ') ++ others ++ Xplugin
   }
 
   def compile(opts0: List[String], sources: List[File]): TestState = {


### PR DESCRIPTION
This is required to *really* pass the `-optimise` flag down to scalac in
PR validation builds. The previous change in
https://github.com/scala/scala-partest/pull/64 passed the flag to
partest but partest didn’t pass the correct settings on to scalac.