### PR TITLE
Mixed Java/Scala compilation like sbt's "Mixed" compileOrder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,22 +4,22 @@ scalaModuleSettings
 
 name                       := "scala-partest"
 
-version                    := "1.0.13-SNAPSHOT"
+version                    := "1.0.19-SNAPSHOT"
 
 scalaVersion               := crossScalaVersions.value.head
 
 crossScalaVersions         := {
   val java = System.getProperty("java.version")
   if (java.startsWith("1.6."))
-    Seq("2.11.7", "2.12.0-M1")
+    Seq("2.11.8")
   else if (java.startsWith("1.8."))
-    Seq("2.12.0-M4")
+    Seq("2.12.1")
   else
     sys.error(s"don't know what Scala versions to build on $java")
 }
 
 scalaXmlVersion            := {
-  if(scalaVersion.value.startsWith("2.11.") || scalaVersion.value == "2.12.0-M2") "1.0.4" else "1.0.5"
+  if (scalaVersion.value.startsWith("2.11.")) "1.0.4" else "1.0.6"
 }
 
 scalaCheckVersion          := "1.11.6"

--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -502,12 +502,10 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner, val nestUI: NestU
   )
   def mixedCompileGroup(allFiles: List[File]): List[CompileRound] = {
     val (scalaFiles, javaFiles) = allFiles partition (_.isScala)
-    val isMixed                 = javaFiles.nonEmpty && scalaFiles.nonEmpty
     val round1                  = if (scalaFiles.isEmpty) None else Some(ScalaAndJava(allFiles))
     val round2                  = if (javaFiles.isEmpty) None else Some(OnlyJava(javaFiles))
-    val round3                  = if (!isMixed) None else Some(OnlyScala(scalaFiles))
 
-    List(round1, round2, round3).flatten
+    List(round1, round2).flatten
   }
 
   def runNegTest() = runInContext {


### PR DESCRIPTION
Partest used to follow an old recommendation for mixed
compilation: first all files are passed to scalac, then
the Java files to javac (with the Scala classfiles on the
classpath), and finally the Scala files again to the Scala
compiler (with the existing classfiles on the classpath).

SBT and the other build tools stop after the second round,
so it makes sense for our partest to do the same by default.

Separate compilation (Java then Scala) can still be tested
using filename groups (`_N`).