### PR TITLE
bump version number, post-release of 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ scalaModuleSettings
 
 name                       := "scala-partest"
 
-version                    := "1.1.0-SNAPSHOT"
+version                    := "1.1.1-SNAPSHOT"
 
 scalaVersion               := crossScalaVersions.value.head
 


### PR DESCRIPTION
it doesn't matter that much since release versions are determined
by tags, but it's nice not to have an out of date version number
when publishLocal'ing a snapshot