### PR TITLE
fix unused warnings

### DIFF
--- a/src/main/scala/scala/tools/partest/PartestTask.scala
+++ b/src/main/scala/scala/tools/partest/PartestTask.scala
@@ -11,9 +11,8 @@ package partest
 
 import scala.tools.nsc.Properties.propOrFalse
 import scala.tools.ant.sabbus.CompilationPathProperty
-import java.lang.reflect.Method
 import org.apache.tools.ant.Task
-import org.apache.tools.ant.types.{ Reference, FileSet }
+import org.apache.tools.ant.types.Reference
 import org.apache.tools.ant.types.Commandline.Argument
 import scala.tools.ant.ScalaTask
 import nest.NestUI

--- a/src/main/scala/scala/tools/partest/StoreReporterDirectTest.scala
+++ b/src/main/scala/scala/tools/partest/StoreReporterDirectTest.scala
@@ -2,7 +2,6 @@ package scala.tools.partest
 
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
-import scala.collection.mutable
 
 trait StoreReporterDirectTest extends DirectTest {
   lazy val storeReporter: StoreReporter = new scala.tools.nsc.reporters.StoreReporter()

--- a/src/main/scala/scala/tools/partest/TestState.scala
+++ b/src/main/scala/scala/tools/partest/TestState.scala
@@ -1,7 +1,5 @@
 package scala.tools.partest
 
-import scala.tools.nsc.util.stackTraceString
-
 sealed abstract class TestState {
   def testFile: java.io.File
   def what: String

--- a/src/main/scala/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/main/scala/scala/tools/partest/nest/AbstractRunner.scala
@@ -9,7 +9,7 @@ package nest
 
 import utils.Properties._
 import scala.tools.nsc.Properties.{ versionMsg, propOrFalse, setProp }
-import scala.collection.{ mutable, immutable }
+import scala.collection.mutable
 import TestKinds._
 import scala.reflect.internal.util.Collections.distinctBy
 

--- a/src/main/scala/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/main/scala/scala/tools/partest/nest/DirectCompiler.scala
@@ -7,12 +7,10 @@ package scala.tools.partest
 package nest
 
 import scala.collection.mutable.ListBuffer
-import scala.tools.nsc.{ Global, Settings, CompilerCommand, FatalError }
+import scala.tools.nsc.{ Global, Settings, CompilerCommand }
 import scala.tools.nsc.reporters.{ Reporter, ConsoleReporter }
-import scala.tools.nsc.util.{ FakePos, stackTraceString }
 import scala.reflect.io.AbstractFile
-import scala.reflect.internal.util.Position
-import java.io.{ BufferedReader, PrintWriter, FileReader, Writer, FileWriter }
+import java.io.{ PrintWriter, FileWriter }
 
 class ExtConsoleReporter(settings: Settings, val writer: PrintWriter) extends ConsoleReporter(settings, Console.in, writer) {
   shortname = true
@@ -72,7 +70,6 @@ class DirectCompiler(val runner: Runner) {
 
   def compile(opts0: List[String], sources: List[File]): TestState = {
     import runner.{ sources => _, _ }
-    import ClassPath.{join, split}
 
     // adding codelib.jar to the classpath
     // codelib provides the possibility to override standard reify

--- a/src/main/scala/scala/tools/partest/nest/FileManager.scala
+++ b/src/main/scala/scala/tools/partest/nest/FileManager.scala
@@ -8,16 +8,7 @@
 package scala.tools.partest
 package nest
 
-import java.io.{
-  File,
-  IOException,
-  OutputStreamWriter,
-  FileOutputStream
-}
-import java.net.URI
-import scala.reflect.io.AbstractFile
-import scala.collection.mutable
-import scala.reflect.internal.util.ScalaClassLoader
+import java.io.{ File, IOException }
 import java.net.URLClassLoader
 
 object FileManager {

--- a/src/main/scala/scala/tools/partest/nest/PathSettings.scala
+++ b/src/main/scala/scala/tools/partest/nest/PathSettings.scala
@@ -5,7 +5,6 @@
 package scala.tools.partest
 package nest
 
-import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.io.{ Path, File, Directory }
 import scala.tools.nsc.Properties.{ propOrNone }
 import Path._
@@ -41,19 +40,6 @@ object PathSettings {
 
   // Directory <root>/test/files or .../scaladoc
   def srcDir = Directory(testRoot / testSourcePath toCanonical)
-
-  // Directory <root>/test/files/lib
-  private def srcLibDir = Directory(srcDir / "lib")
-
-  // Directory <root>/build
-  private def buildDir: Directory = {
-    val bases      = testRoot :: testRoot.parents
-    // In the classic "ant" build, the relevant subdirectory is called build,
-    // but in the postmodern "sbt" build, it is called target.  Look for both.
-    val dirs = Path.onlyDirs(bases flatMap (x => List(x / "build", x / "target")))
-
-    dirs.headOption getOrElse sys.error("Neither 'build' nor 'target' dir found under test root " + testRoot + ".")
-  }
 
   def srcSpecLib     = findJar("instrumented", Directory(srcDir / "speclib"))
   def srcCodeLib     = findJar("code",  Directory(srcDir / "codelib"), Directory(testRoot / "files" / "codelib") /* work with --srcpath pending */)

--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -6,25 +6,22 @@ package scala.tools.partest
 package nest
 
 import java.io.{ Console => _, _ }
-import java.net.URL
-import java.nio.charset.{ Charset, CharsetDecoder, CharsetEncoder, CharacterCodingException, CodingErrorAction => Action }
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit.NANOSECONDS
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.Duration
-import scala.io.Codec
 import scala.reflect.internal.FatalError
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.sys.process.{ Process, ProcessLogger }
-import scala.tools.nsc.Properties.{ envOrNone, isWin, jdkHome, javaHome, propOrEmpty, setProp, versionMsg, javaVmName, javaVmVersion, javaVmInfo }
+import scala.tools.nsc.Properties.{ envOrNone, isWin, javaHome, propOrEmpty, versionMsg, javaVmName, javaVmVersion, javaVmInfo }
 import scala.tools.nsc.{ Settings, CompilerCommand, Global }
 import scala.tools.nsc.reporters.ConsoleReporter
-import scala.tools.nsc.util.{ Exceptional, stackTraceString }
+import scala.tools.nsc.util.stackTraceString
 import scala.util.{ Try, Success, Failure }
 import ClassPath.{ join, split }
 import TestState.{ Pass, Fail, Crash, Uninitialized, Updated }
 
-import FileManager.{ compareFiles, compareContents, joinPaths, withTempFile }
+import FileManager.{ compareContents, joinPaths, withTempFile }
 
 trait TestInfo {
   /** pos/t1234 */

--- a/src/main/scala/scala/tools/partest/package.scala
+++ b/src/main/scala/scala/tools/partest/package.scala
@@ -7,7 +7,7 @@ package scala.tools
 import java.util.concurrent.{ Callable, ExecutorService }
 import scala.concurrent.duration.Duration
 import scala.sys.process.javaVmArguments
-import scala.tools.nsc.util.{ ScalaClassLoader, Exceptional }
+import scala.tools.nsc.util.Exceptional
 
 package object partest {
   type File         = java.io.File


### PR DESCRIPTION
there isn't a 2.12.2 nightly quite yet with scala/scala#5402 in it,
but I tested with ++2.12.2-bin-bad61ce-SNAPSHOT

~~the sbt version bump is unrelated~~ (removed)