### PR TITLE
Use readOptionFile and don't trim aggressively

### DIFF
--- a/src/main/scala/scala/tools/partest/package.scala
+++ b/src/main/scala/scala/tools/partest/package.scala
@@ -147,7 +147,7 @@ package object partest {
   def readOptionsFile(file: File): List[String] = {
     file.fileLines match {
       case x :: Nil   => words(x)
-      case xs         => xs map (_.trim)
+      case xs         => xs
     }
   }
 


### PR DESCRIPTION
Conventionally, a multiline file means take each line
as an element, no quote parsing required. To support
trailing spaces, do not aggressively trim the input;
that was probably to avoid confusion over a nonempty
line consistently only of spaces; but still do drop
empty elements, that is, a line of zero length.
An empty line is useful to force multiline handling
of a single element. (A single line is split on space.)