### PR TITLE
Propagate exceptions and failure transcripts to the SBT test listener…

### DIFF
--- a/src/main/scala/scala/tools/partest/sbt/SBTRunner.scala
+++ b/src/main/scala/scala/tools/partest/sbt/SBTRunner.scala
@@ -85,7 +85,8 @@ class SBTRunner(val config: RunnerSpec.Config,
     case Pass(_)          => (Status.Success, new OptionalThrowable)
     case Updated(_)       => (Status.Success, new OptionalThrowable)
     case Skip(_, _)       => (Status.Skipped, new OptionalThrowable)
-    case Fail(_, _, _)    => (Status.Failure, new OptionalThrowable)
+    case Fail(_, reason, transcript)    => (Status.Failure, new OptionalThrowable(new TestFailedThrowable(reason, transcript.mkString("\n"))))
     case Crash(_, e, _)   => (Status.Error, new OptionalThrowable(e))
   }
 }
+class TestFailedThrowable(reason: String, transcript: String) extends Throwable(reason + "\n\n" + transcript)


### PR DESCRIPTION
Review by @som-snytt | @szeiger 

Together with https://github.com/scala/scala/pull/6313, the goal is present an aggregated display of JUnit and Partest results in the Jenkins UI.