### PR TITLE
Add a mode to reuse JVM for test execution

### DIFF
--- a/src/main/scala/scala/tools/partest/PartestDefaults.scala
+++ b/src/main/scala/scala/tools/partest/PartestDefaults.scala
@@ -15,8 +15,18 @@ object PartestDefaults {
 
   def testBuild   = prop("partest.build")
   def errorCount  = prop("partest.errors")  map (_.toInt) getOrElse 0
-  def numThreads  = prop("partest.threads") map (_.toInt) getOrElse runtime.availableProcessors
+  def numThreads  = math.max(1, prop("partest.threads") map (_.toInt) getOrElse runtime.availableProcessors)
+  def execInProcess: Boolean = {
+    val prop = java.lang.Boolean.getBoolean("partest.exec.in.process")
+    if (prop && numThreads > 1) warningMessage
+    prop
+  }
+  private lazy val warningMessage: Unit = {
+    println("Note: test execution will be non-parallel under -Dpartest.exec.in.process")
+  }
+
   def waitTime    = Duration(prop("partest.timeout") getOrElse "4 hours")
+  def printDurationThreshold = java.lang.Integer.getInteger("partest.print.duration.threshold.ms", 5000)
 
   //def timeout     = "1200000"   // per-test timeout
 

--- a/src/main/scala/scala/tools/partest/nest/DelegatingSecurityManager.scala
+++ b/src/main/scala/scala/tools/partest/nest/DelegatingSecurityManager.scala
@@ -1,0 +1,34 @@
+package scala.tools.partest.nest
+
+import java.io.FileDescriptor
+import java.net.InetAddress
+import java.security.Permission
+
+class DelegatingSecurityManager(delegate: SecurityManager) extends SecurityManager {
+  override def checkExit(status: Int): Unit = if (delegate ne null) delegate.checkExit(status)
+  override def checkPermission(perm: Permission): Unit = if (delegate ne null) delegate.checkPermission(perm)
+  override def checkPermission(perm: Permission, context: AnyRef): Unit = if (delegate ne null) delegate.checkPermission(perm, context)
+  override def checkExec(cmd: String): Unit = if (delegate ne null) delegate.checkExec(cmd)
+  override def checkWrite(file: String): Unit = if (delegate ne null) delegate.checkWrite(file)
+  override def checkDelete(file: String): Unit = if (delegate ne null) delegate.checkDelete(file)
+  override def checkRead(file: String): Unit = if (delegate ne null) delegate.checkRead(file)
+  override def checkRead(file: String, context: scala.Any): Unit = if (delegate ne null) delegate.checkRead(file, context)
+  override def checkPropertyAccess(key: String): Unit = if (delegate ne null) delegate.checkPropertyAccess(key)
+  override def checkAccept(host: String, port: Int): Unit = if (delegate ne null) delegate.checkAccept(host, port)
+  override def checkWrite(fd: FileDescriptor): Unit = if (delegate ne null) delegate.checkWrite(fd)
+  override def checkPrintJobAccess(): Unit = if (delegate ne null) delegate.checkPrintJobAccess()
+  override def checkMulticast(maddr: InetAddress): Unit = if (delegate ne null) delegate.checkMulticast(maddr)
+  override def checkSetFactory(): Unit = if (delegate ne null) delegate.checkSetFactory()
+  override def checkLink(lib: String): Unit = if (delegate ne null) delegate.checkLink(lib)
+  override def checkSecurityAccess(target: String): Unit = if (delegate ne null) delegate.checkSecurityAccess(target)
+  override def checkListen(port: Int): Unit = if (delegate ne null) delegate.checkListen(port)
+  override def checkAccess(t: Thread): Unit = if (delegate ne null) delegate.checkAccess(t)
+  override def checkAccess(g: ThreadGroup): Unit = if (delegate ne null) delegate.checkAccess(g)
+  override def checkCreateClassLoader(): Unit = if (delegate ne null) delegate.checkCreateClassLoader()
+  override def checkPackageDefinition(pkg: String): Unit = if (delegate ne null) delegate.checkPackageDefinition(pkg)
+  override def checkConnect(host: String, port: Int): Unit = if (delegate ne null) delegate.checkConnect(host, port)
+  override def checkConnect(host: String, port: Int, context: scala.Any): Unit = if (delegate ne null) delegate.checkConnect(host, port, context)
+  override def checkPackageAccess(pkg: String): Unit = if (delegate ne null) delegate.checkPackageAccess(pkg)
+  override def checkPropertiesAccess(): Unit = if (delegate ne null) delegate.checkPropertiesAccess()
+  override def checkRead(fd: FileDescriptor): Unit = if (delegate ne null) delegate.checkRead(fd)
+}

--- a/src/main/scala/scala/tools/partest/nest/NestUI.scala
+++ b/src/main/scala/scala/tools/partest/nest/NestUI.scala
@@ -52,7 +52,7 @@ class NestUI(val verbose: Boolean = false, val debug: Boolean = false, val terse
     }
   }
 
-  def statusLine(state: TestState) = {
+  def statusLine(state: TestState, durationMs: Long) = {
     import state._
     import TestState._
     val colorizer = state match {
@@ -62,10 +62,11 @@ class NestUI(val verbose: Boolean = false, val debug: Boolean = false, val terse
       case _           => red
     }
     val word = bold(colorizer(state.shortStatus))
-    f"$word $testNumber - $testIdent%-40s$reasonString"
+    def durationString = if (durationMs > PartestDefaults.printDurationThreshold) f"[duration ${(1.0 * durationMs) / 1000}%.2fs]" else ""
+    f"$word $testNumber - $testIdent%-40s$reasonString$durationString"
   }
 
-  def reportTest(state: TestState, info: TestInfo): Unit = {
+  def reportTest(state: TestState, info: TestInfo, durationMs: Long): Unit = {
     if (terse && state.isOk) {
       if (dotCount >= DotWidth) {
         outline("\n.")
@@ -75,7 +76,7 @@ class NestUI(val verbose: Boolean = false, val debug: Boolean = false, val terse
         dotCount += 1
       }
     } else {
-      echo(statusLine(state))
+      echo(statusLine(state, durationMs))
       if (!state.isOk) {
         def showLog() = if (info.logFile.canRead) {
           echo(bold(cyan(s"##### Log file '${info.logFile}' from failed test #####\n")))

--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -131,9 +131,7 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner, val nestUI: NestU
     )
 
     pushTranscript(args mkString " ")
-    val captured = StreamCapture(runCommand(args, logFile))
-    if (captured.result) genPass() else {
-      logFile appendAll captured.stderr
+    if (runCommand(args, logFile)) genPass() else {
       genFail("java compilation failed")
     }
   }

--- a/src/main/scala/scala/tools/partest/nest/Runner.scala
+++ b/src/main/scala/scala/tools/partest/nest/Runner.scala
@@ -293,9 +293,6 @@ class Runner(val testFile: File, val suiteRunner: SuiteRunner, val nestUI: NestU
 
       TrapExit(() => run()) match {
         case Left((status, throwable)) if status != 0 =>
-          //        Files.readAllLines(log.toPath).forEach(println(_))
-          //        val error = new AssertionError(s"System.exit(${status}) was called.")
-          //        error.setStackTrace(throwable.getStackTrace)
           setLastState(genFail("non-zero exit code"))
           false
         case _ =>

--- a/src/main/scala/scala/tools/partest/nest/Stopwatch.scala
+++ b/src/main/scala/scala/tools/partest/nest/Stopwatch.scala
@@ -1,6 +1,10 @@
 package scala.tools.partest.nest
 
-class Stopwatch {
+/**
+  * Measured elapsed time between between calls to `start` and `stop`.
+  * May be `pause`-ed and re-`started` before `stop` is eventually called.
+  */
+final class Stopwatch {
   private var base: Option[Long] = None
   private var elapsed = 0L
   def pause(): Unit = {

--- a/src/main/scala/scala/tools/partest/nest/Stopwatch.scala
+++ b/src/main/scala/scala/tools/partest/nest/Stopwatch.scala
@@ -1,0 +1,20 @@
+package scala.tools.partest.nest
+
+class Stopwatch {
+  private var base: Option[Long] = None
+  private var elapsed = 0L
+  def pause(): Unit = {
+    assert(base.isDefined)
+    val now = System.nanoTime
+    elapsed += (now - base.get)
+    base = None
+  }
+  def start(): Unit = {
+    base = Some(System.nanoTime())
+  }
+
+  def stop(): Long = {
+    pause()
+    (1.0 * elapsed / 1000 / 1000).toLong
+  }
+}

--- a/src/main/scala/scala/tools/partest/nest/StreamCapture.scala
+++ b/src/main/scala/scala/tools/partest/nest/StreamCapture.scala
@@ -9,23 +9,6 @@ import java.io.{Console => _, _}
 import java.nio.charset.Charset
 
 object StreamCapture {
-  case class Captured[T](stdout: String, stderr: String, result: T) {
-    override def toString = s"""
-      |result: $result
-      |[stdout]
-      |$stdout
-      |[stderr]
-      |$stderr""".stripMargin.trim
-  }
-
-  private def mkStream = {
-    val swr     = new StringWriter
-    val wr      = new PrintWriter(swr, true)
-    val ostream = new PrintStream(new OutputStream { def write(b: Int): Unit = wr write b }, true) // autoFlush = true
-
-    (ostream, () => { ostream.close() ; swr.toString })
-  }
-
   def savingSystem[T](body: => T): T = {
     val savedOut  = System.out
     val savedErr  = System.err
@@ -34,22 +17,6 @@ object StreamCapture {
       System setErr savedErr
       System setOut savedOut
     }
-  }
-
-  def apply[T](body: => T): Captured[T] = {
-    val (outstream, stdoutFn) = mkStream
-    val (errstream, stderrFn) = mkStream
-
-    val result = savingSystem {
-      System setOut outstream
-      System setErr errstream
-      Console.withOut(outstream) {
-        Console.withErr(errstream) {
-          body
-        }
-      }
-    }
-    Captured(stdoutFn(), stderrFn(), result)
   }
 
   def capturingOutErr[A](output: OutputStream)(f: => A): A = {

--- a/src/main/scala/scala/tools/partest/nest/StreamCapture.scala
+++ b/src/main/scala/scala/tools/partest/nest/StreamCapture.scala
@@ -5,7 +5,8 @@
 package scala.tools.partest
 package nest
 
-import java.io.{ Console => _, _ }
+import java.io.{Console => _, _}
+import java.nio.charset.Charset
 
 object StreamCapture {
   case class Captured[T](stdout: String, stderr: String, result: T) {
@@ -49,5 +50,43 @@ object StreamCapture {
       }
     }
     Captured(stdoutFn(), stderrFn(), result)
+  }
+
+  def withExtraProperties[A](extra: Map[String, String])(action: => A): A = {
+    val saved = System.getProperties()
+    val modified = new java.util.Properties()
+    saved.stringPropertyNames().forEach((k) => modified.setProperty(k, saved.getProperty(k)))
+    extra.foreach { case (k, v) => modified.setProperty(k, v) }
+    System.setProperties(modified)
+    try {
+      action
+    } finally {
+      System.setProperties(saved)
+    }
+  }
+
+  // TODO merge with code above
+  def capturingOutErr[A](output: OutputStream)(f: => A): A = {
+    import java.io._
+    val savedOut = System.out
+    val savedErr = System.err
+    try {
+      val charset = Charset.defaultCharset()
+      val printStream = new PrintStream(output, true, charset.name())
+      try {
+        System.setOut(printStream)
+        System.setErr(printStream)
+        scala.Console.withErr(printStream) {
+          scala.Console.withOut(printStream) {
+            f
+          }
+        }
+      } finally {
+        printStream.close()
+      }
+    } finally {
+      System.setOut(savedOut)
+      System.setOut(savedErr)
+    }
   }
 }

--- a/src/main/scala/scala/tools/partest/nest/TrapExit.scala
+++ b/src/main/scala/scala/tools/partest/nest/TrapExit.scala
@@ -1,0 +1,24 @@
+package scala.tools.partest.nest
+
+object TrapExit {
+
+  private class TrapExitThrowable(val status: Int) extends Throwable {
+    override def getMessage: String = throw this
+    override def getCause: Throwable = throw this
+  }
+
+  def apply[A](action: () => A): Either[(Int, Throwable), A] = {
+    val saved = System.getSecurityManager
+    System.setSecurityManager(new DelegatingSecurityManager(saved) {
+      override def checkExit(status: Int): Unit = throw new TrapExitThrowable(status)
+    })
+    try {
+      Right(action())
+    } catch {
+      case te: TrapExitThrowable =>
+        Left((te.status, te))
+    } finally {
+      System.setSecurityManager(saved)
+    }
+  }
+}


### PR DESCRIPTION
The cost of VM startup and JIT is the predominant reason that
`partest --run` is slow. We're much better of using one thread
on the main JVM to execute these tests.

This commit uses such a mode under a non-default option.

Unforked test execution requires some care:

  - we need to check the main JVM is started with the mandated
    immutable System properties (e.g. file.encoding)
  - other test-specific system properties (e.g. partest.output)
    need to be patched into the system property map before
    each test is executed.
  - sys.exit calls need to be intercepted with a security manager
  - stdout / stderr need to be intercepted, both in the Java and
    Scala console printing APIs.

Some tests need to be adapted, in particular those that assume
that java.class.path will contain the test classes.

Tests can also force usage of the legacy forked mode by adding
a .javaopts file with a dummy JVM option.

Also improve recording of test durations and flag slow tests in
console output.