### PR TITLE
some changes so it compiles on Java 9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/src/main/scala/scala/tools/partest/nest/StreamCapture.scala
+++ b/src/main/scala/scala/tools/partest/nest/StreamCapture.scala
@@ -41,7 +41,12 @@ object StreamCapture {
   def withExtraProperties[A](extra: Map[String, String])(action: => A): A = {
     val saved = System.getProperties()
     val modified = new java.util.Properties()
-    modified.putAll(saved)
+    // on Java 9, we need to cast our way around this:
+    // src/main/scala/scala/tools/partest/nest/StreamCapture.scala:44: ambiguous reference to overloaded definition,
+    // both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
+    // and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
+    // match argument types (java.util.Properties)
+    (modified: java.util.Hashtable[AnyRef, AnyRef]).putAll(saved)
     extra.foreach { case (k, v) => modified.setProperty(k, v) }
     // Trying to avoid other threads seeing the new properties object prior to the new entries
     // https://github.com/scala/scala/pull/6391#issuecomment-371346171

--- a/src/main/scala/scala/tools/partest/package.scala
+++ b/src/main/scala/scala/tools/partest/package.scala
@@ -97,7 +97,7 @@ package object partest {
      */
     def instantiate[A >: Null](name: String): A = (
       catching(classOf[ClassNotFoundException], classOf[SecurityException]) opt
-      (loader loadClass name).newInstance.asInstanceOf[A] orNull
+      (loader loadClass name).getConstructor().newInstance().asInstanceOf[A] orNull
     )
   }
 


### PR DESCRIPTION
we don't really strictly need partest to compile on Java 9,
but the needed changes are small

this came up in the context of the Scala 2.12-on-Java-9 community build