### PR TITLE
allow JDK 10 & 11, drop Scala 2.13, bump 2.12.4 -> 2.12.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,9 @@ scalaVersionsByJvm in ThisBuild := {
 
   Map(
     8 -> vs.map(_ -> true),
-    9 -> vs.map(_ -> false))
+    9 -> vs.map(_ -> false),
+    10 -> vs.map(_ -> false),
+    11 -> vs.map(_ -> false))
 }
 
 scalaXmlVersion := "1.0.6"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name    := "scala-partest"
 version := "1.1.4-SNAPSHOT"
 
 scalaVersionsByJvm in ThisBuild := {
-  val vs = List("2.12.4", "2.13.0-M3")
+  val vs = List("2.12.6", "2.13.0-M3")
 
   Map(
     8 -> vs.map(_ -> true),

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name    := "scala-partest"
 version := "1.1.4-SNAPSHOT"
 
 scalaVersionsByJvm in ThisBuild := {
-  val vs = List("2.12.6", "2.13.0-M3")
+  val vs = List("2.12.6")
 
   Map(
     8 -> vs.map(_ -> true),


### PR DESCRIPTION
* 2.13 not needed anymore since partest we re-in-sourced into scala/scala
* JDK 10/11: Scala community build on JDK 10. might as well throw 11 in too.
* 2.12.6 bump is just general dogfooding